### PR TITLE
ベクトル演算に要求する制約を拡充

### DIFF
--- a/sjrt/src/lib.rs
+++ b/sjrt/src/lib.rs
@@ -16,7 +16,7 @@ pub use system::ParallelizeSystem;
 pub use traits::EnumerateLightResult;
 pub use traits::IBuffer;
 pub use traits::IRenderer;
-pub use traits::IScene;
+pub use traits::{IConstract, IInnerProduct, INorm, IOuterProduct, IScene};
 
 mod bidirectional_reflectance_distribution_function;
 pub use bidirectional_reflectance_distribution_function::IBidirectionalReflectanceDistributionFunction;

--- a/sjrt/src/property.rs
+++ b/sjrt/src/property.rs
@@ -1,4 +1,4 @@
-use crate::{traits::IVectorComponent3, Brdf};
+use crate::{traits::IVectorComponent3, Brdf, IConstract};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Property<TFloat, TVectorComponent>
@@ -17,7 +17,7 @@ where
 impl<TFloat, TVectorComponent> Default for Property<TFloat, TVectorComponent>
 where
     TFloat: num::Float,
-    TVectorComponent: IVectorComponent3<TFloat>,
+    TVectorComponent: IVectorComponent3<TFloat> + IConstract<TFloat>,
 {
     fn default() -> Self {
         Self {

--- a/sjrt/src/sampling_algorithm/default_sampling_estimation.rs
+++ b/sjrt/src/sampling_algorithm/default_sampling_estimation.rs
@@ -3,7 +3,7 @@ use std::ops::{Add, Mul, Range};
 
 use crate::sampling_algorithm::SamplingResult;
 use crate::traits::{IInnerProduct, INormalized, IRandomEngine, IVectorComponent3};
-use crate::IScene;
+use crate::{IConstract, IScene};
 use rand::Rng;
 
 #[derive(Default)]
@@ -27,6 +27,7 @@ impl DefaultSamplingEstimation {
             + PartialOrd<TFloat>
             + Mul<TVector3, Output = TVector3>,
         TVector3: IVectorComponent3<TFloat>
+            + IConstract<TFloat>
             + INormalized
             + IInnerProduct<TFloat>
             + Add<TVector3, Output = TVector3>
@@ -92,6 +93,7 @@ where
     where
         TFloat: num::Float + From<f32> + PartialOrd<TFloat> + Mul<TVector3, Output = TVector3>,
         TVector3: IVectorComponent3<TFloat>
+            + IConstract<TFloat>
             + INormalized
             + IInnerProduct<TFloat>
             + Add<TVector3, Output = TVector3>

--- a/sjrt/src/sampling_algorithm/nee.rs
+++ b/sjrt/src/sampling_algorithm/nee.rs
@@ -2,7 +2,7 @@ use std::ops::{Add, Mul, Sub};
 
 use crate::sampling_algorithm::SamplingResult;
 use crate::traits::{IInnerProduct, INormalized, IVectorComponent3};
-use crate::IScene;
+use crate::{IConstract, IScene};
 use rand::prelude::*;
 
 pub trait IRelatedLightEnumerator<TFloat, TVector3>
@@ -35,6 +35,7 @@ impl NextEventEstimation {
         TVector3: INormalized
             + IInnerProduct<TFloat>
             + IVectorComponent3<TFloat>
+            + IConstract<TFloat>
             + Add<TVector3, Output = TVector3>
             + Sub<TVector3, Output = TVector3>
             + Copy,

--- a/sjrt/src/traits.rs
+++ b/sjrt/src/traits.rs
@@ -44,8 +44,6 @@ pub trait IVectorComponent3<TFloat>
 where
     TFloat: num::Float,
 {
-    fn new(x: TFloat, y: TFloat, z: TFloat) -> Self;
-
     fn x(&self) -> TFloat;
 
     fn y(&self) -> TFloat;
@@ -59,6 +57,14 @@ where
     fn set_z(&mut self, z: TFloat);
 }
 
+pub trait IConstract<TFloat: num::Float> {
+    fn new(x: TFloat, y: TFloat, z: TFloat) -> Self;
+}
+
+pub trait INorm {
+    fn norm(&self) -> f32;
+}
+
 pub trait INormalized {
     fn normalized(&self) -> Self;
 }
@@ -68,6 +74,10 @@ where
     T: num::Float,
 {
     fn dot(&self, other: &Self) -> T;
+}
+
+pub trait IOuterProduct {
+    fn cross(&self, other: &Self) -> Self;
 }
 
 pub trait IRandomEngine<TFloat>

--- a/sjrt/src/types.rs
+++ b/sjrt/src/types.rs
@@ -1,4 +1,4 @@
-use crate::traits::IVectorComponent3;
+use crate::{traits::IVectorComponent3, IConstract};
 
 pub struct Colors<TFloat, TVectorComponent>
 where
@@ -10,7 +10,7 @@ where
 
 impl<TVectorComponent> Colors<f32, TVectorComponent>
 where
-    TVectorComponent: IVectorComponent3<f32>,
+    TVectorComponent: IVectorComponent3<f32> + IConstract<f32>,
 {
     pub fn white() -> TVectorComponent {
         TVectorComponent::new(1.0, 1.0, 1.0)

--- a/sjrt/src/util/rapier_scene.rs
+++ b/sjrt/src/util/rapier_scene.rs
@@ -4,7 +4,7 @@ use crate::{
     sampling_algorithm::IRelatedLightEnumerator,
     scene::Scene,
     traits::{EnumerateLightResult, IVectorComponent3},
-    IScene, MaterialInfo, Property,
+    IConstract, IScene, MaterialInfo, Property,
 };
 use rapier3d::{parry::partitioning::IndexedData, prelude::*};
 
@@ -162,7 +162,7 @@ impl IScene for RapierScene {
 impl<TFloat, TVector3> IRelatedLightEnumerator<TFloat, TVector3> for RapierScene
 where
     TFloat: num::Float + From<f32>,
-    TVector3: IVectorComponent3<TFloat>,
+    TVector3: IVectorComponent3<TFloat> + IConstract<TFloat>,
 {
     fn enumerate(&self, _position: &TVector3) -> impl Iterator<Item = TVector3> {
         let mut results = Vec::new();

--- a/sjrt/src/util/vector.rs
+++ b/sjrt/src/util/vector.rs
@@ -1,13 +1,12 @@
-use crate::traits::{IInnerProduct, INormalized, IVectorComponent3};
+use crate::{
+    traits::{IInnerProduct, INormalized, IVectorComponent3},
+    IConstract, INorm, IOuterProduct,
+};
 
 impl<TFloat> IVectorComponent3<TFloat> for nalgebra::Vector3<TFloat>
 where
     TFloat: num::Float + nalgebra::Scalar,
 {
-    fn new(x: TFloat, y: TFloat, z: TFloat) -> Self {
-        Self::new(x, y, z)
-    }
-
     fn x(&self) -> TFloat {
         self.x
     }
@@ -33,12 +32,27 @@ where
     }
 }
 
+impl<T> IConstract<T> for nalgebra::Vector3<T>
+where
+    T: num::Float,
+{
+    fn new(x: T, y: T, z: T) -> Self {
+        nalgebra::Vector3::new(x, y, z)
+    }
+}
+
 impl<T> INormalized for nalgebra::Vector3<T>
 where
     T: nalgebra::Scalar + nalgebra::SimdComplexField,
 {
     fn normalized(&self) -> Self {
         self.normalize()
+    }
+}
+
+impl INorm for nalgebra::Vector3<f32> {
+    fn norm(&self) -> f32 {
+        self.norm()
     }
 }
 
@@ -52,5 +66,17 @@ where
 {
     fn dot(&self, other: &Self) -> T {
         self.dot(other)
+    }
+}
+
+impl<T: num::Float> IOuterProduct for nalgebra::Vector3<T>
+where
+    T: nalgebra::Scalar
+        + nalgebra::ClosedAddAssign
+        + nalgebra::ClosedSubAssign
+        + nalgebra::ClosedMulAssign,
+{
+    fn cross(&self, other: &Self) -> Self {
+        self.cross(other)
     }
 }


### PR DESCRIPTION
各種操作で必要な処理を適切に指定できるように粒度を変えた